### PR TITLE
MongoDB closing quote

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import GroupsController from "./groups/groups-controller";
 import FollowsController from "./follows/follows-controller";
 
 const CONNECTION_STRING = process.env.DB_CONNECTION_STRING
- || 'mongodb://127.0.0.1:27017/seasoned-recipes-db
+ || 'mongodb://127.0.0.1:27017/seasoned-recipes-db'
 mongoose.connect(CONNECTION_STRING);
 
 // EXPRESS CONNECT AND CONFIGURATION


### PR DESCRIPTION
Deleted CONNECTION_STRING closing quote due to typo, causing deployment failures. Have re-added.